### PR TITLE
Fix clue communication between robots

### DIFF
--- a/pololu_search_sim.py
+++ b/pololu_search_sim.py
@@ -152,23 +152,24 @@ class RobotAgent:
             return
         if sender != self.other_id:
             return
-        if topic.startswith("status:intent:"):
-            xy = topic.split("status:intent:",1)[1]
+        if topic == "status" and payload.startswith("intent:"):
+            xy = payload.split("intent:",1)[1]
             try:
                 x,y = [int(v) for v in xy.split(",")]
                 self.other_intent = (x,y)
                 self.other_intent_ttl = self.cfg.INTENT_TTL_STEPS
-            except:
+            except Exception:
                 pass
-        elif topic.startswith("alert:object:"):
+        elif topic == "alert" and payload.startswith("object:"):
             self.found_object = True
-        elif topic.startswith("clue:clue:"):
-            xy = topic.split("clue:clue:",1)[1]
+        elif topic == "clue" and payload.startswith("clue:"):
+            xy = payload.split("clue:",1)[1]
             try:
                 x,y = [int(v) for v in xy.split(",")]
                 if (x,y) not in self.clues:
-                    self.clues.append((x,y)); self.first_clue_seen = True
-            except:
+                    self.clues.append((x,y))
+                    self.first_clue_seen = True
+            except Exception:
                 pass
 
     def _edge_distance_from_side(self, x: int) -> int:


### PR DESCRIPTION
## Summary
- Correct message parsing so robots interpret topics and payloads separately
- Ensure clue notifications and intents are received by other robots

## Testing
- `python pololu_search_sim.py --mode batch --episodes 1 --grid 5 --seed 1`
- Custom script verifying both robots register shared clue

------
https://chatgpt.com/codex/tasks/task_e_689e57ccbb8083279d6db30852ec63df